### PR TITLE
Default minimum.progress value is 0.

### DIFF
--- a/dga-giraph/src/main/java/com/soteradefense/dga/LouvainRunner.java
+++ b/dga-giraph/src/main/java/com/soteradefense/dga/LouvainRunner.java
@@ -59,7 +59,7 @@ public class LouvainRunner {
         minimalDefaultConfiguration = new DGAConfiguration();
         minimalDefaultConfiguration.setSystemProperty("giraph.useSuperstepCounters", "false");
         minimalDefaultConfiguration.setCustomProperty("actual.Q.aggregators", "1");
-        minimalDefaultConfiguration.setCustomProperty("minimum.progress", "2000");
+        minimalDefaultConfiguration.setCustomProperty("minimum.progress", "0");
         minimalDefaultConfiguration.setCustomProperty("progress.tries", "1");
         configuration = new Configuration();
     }


### PR DESCRIPTION
A default minimum.progress value is 0 according to following instructions.
http://sotera.github.io/distributed-graph-analytics/louvain/#louvainconfig
But minimum.progress is assigned 2000 as default.

If the value of minimum.progress is 2000, a louvain computaion will end in the middle of processing.
